### PR TITLE
Pre-hide posts with URL under spoilers

### DIFF
--- a/util/check-message-for-links.js
+++ b/util/check-message-for-links.js
@@ -94,9 +94,17 @@ const CheckMessageForLinks = (ctx, message, ableToDeleteSource = false) => {
     messageEntities[0].offset === 0 &&
     messageEntities[0].length === messageText.length;
 
-  if (containsOneAndOnlyLink) {
+  const containsOneAndOnlySpoilerLink =
+    messageEntities?.length === 2 &&
+    messageEntities[0].type === 'url' &&
+    messageEntities[1].type === 'spoiler' &&
+    messageEntities[0].offset === 0 &&
+    messageEntities[0].length === messageText.length &&
+    messageEntities[1].length === messageText.length;
+
+  if (containsOneAndOnlyLink || containsOneAndOnlySpoilerLink) {
     const checkedLink = CheckForLink(messageText);
-    if (checkedLink?.status) MakePost(ctx, checkedLink, ableToDeleteSource);
+    if (checkedLink?.status) MakePost(ctx, checkedLink, ableToDeleteSource, containsOneAndOnlySpoilerLink);
     return;
   }
 

--- a/util/make-post.js
+++ b/util/make-post.js
@@ -15,7 +15,7 @@ import { SocialPick, VideoDone } from './social-picker.js';
  * @param {boolean} [deleteSource]
  * @returns {void}
  */
-const MakePost = (ctx, checkedLink, deleteSource = false) => {
+const MakePost = (ctx, checkedLink, deleteSource = false, hidden = false) => {
   const { from } = ctx;
 
   SocialPick(checkedLink.url)
@@ -84,7 +84,7 @@ const MakePost = (ctx, checkedLink, deleteSource = false) => {
         const extra = {
           disable_web_page_preview: true,
           parse_mode: 'HTML',
-          caption,
+          caption: hidden ? `<tg-spoiler>${caption}</tg-spoiler>` : caption,
           reply_to_message_id: deleteSource
             ? ctx.message.reply_to_message
               ? ctx.message.reply_to_message.message_id
@@ -114,6 +114,7 @@ const MakePost = (ctx, checkedLink, deleteSource = false) => {
                 : null,
             ].filter(Boolean)
           ).reply_markup,
+          has_spoiler: hidden ? true : false,
         };
 
         if (media.type === 'video') extra.supports_streaming = true;
@@ -176,6 +177,7 @@ const MakePost = (ctx, checkedLink, deleteSource = false) => {
           caption: `<a href="${encodeURI(
             media.original || media.externalUrl || socialPost.postURL
           )}">Исходник файла</a>`,
+          has_spoiler: hidden ? true : false,
         }));
 
         /** @type {import('../types/telegraf').MediaGroupExtra} */
@@ -195,7 +197,7 @@ const MakePost = (ctx, checkedLink, deleteSource = false) => {
 
             return SendingWrapper(() =>
               ctx
-                .sendMessage(caption, {
+                .sendMessage(hidden ? `<tg-spoiler>${caption}</tg-spoiler>` : caption, {
                   disable_web_page_preview: true,
                   parse_mode: 'HTML',
                   disable_notification: true,


### PR DESCRIPTION
Ответы на сообщения, содержащие только ссылку под спойлером отправляются сразу под спойлером

Вроде ничего не сломалось
Проверил работоспособность:
- Одиночные посты
- Альбомы
- Видео (на примере YT)